### PR TITLE
Added cert.sh + Modified Dockerfiles

### DIFF
--- a/viz_scripts/Dockerfile
+++ b/viz_scripts/Dockerfile
@@ -5,8 +5,9 @@ VOLUME /plots
 
 ENV DB_HOST=db
 ENV WEB_SERVER_HOST=0.0.0.0
-ENV CRON_MODE= 
+ENV CRON_MODE=TRUE 
 ENV STUDY_CONFIG=stage-program
+ENV PROD_STAGE=TRUE
 
 ADD docker/environment36.dashboard.additions.yml /
 
@@ -37,6 +38,10 @@ ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
 RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
 
 ADD docker/crontab /usr/src/app/crontab
+
+ADD docker/cert.sh /usr/src/app/.docker/cert.sh
+RUN chmod u+x /usr/src/app/.docker/cert.sh
+RUN /usr/src/app/.docker/cert.sh
 
 EXPOSE 8888
 

--- a/viz_scripts/docker/cert.sh
+++ b/viz_scripts/docker/cert.sh
@@ -1,0 +1,6 @@
+if [ -z ${PROD_STAGE} ] ; then
+    echo “Not in staging / production environment, continuing build...” 
+elif [ ${PROD_STAGE} = "TRUE" ] ; then
+    wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -O /etc/ssl/certs/rds-combined-ca-bundle.pem
+    echo "In staging / production environment, added AWS certificates"
+fi


### PR DESCRIPTION
1. docker/cert.sh
- Uses new environment variable PROD_STAGE variable to determine whether in staging / production environment and only then install certificates, else skip.

2. Dockerfile Added environment variables here, keeping the same default ENV values as the ones in docker-compose.yml. Not adding in docker/Dockerfile.dev, since this change is being done primarily with the objective to aid with the automated build and push to Dockerhub. This pushed image would then be the one that would be used in the internal environments as the base image, which would be based on the non-dev Dockerfile.