### PR TITLE
Removing ENV variables from Dockerfile

### DIFF
--- a/viz_scripts/Dockerfile
+++ b/viz_scripts/Dockerfile
@@ -3,12 +3,6 @@ FROM shankari/e-mission-server:master_2024-02-10--19-38
 
 VOLUME /plots
 
-ENV DB_HOST=db
-ENV WEB_SERVER_HOST=0.0.0.0
-ENV CRON_MODE=TRUE 
-ENV STUDY_CONFIG=stage-program
-ENV PROD_STAGE=TRUE
-
 ADD docker/environment36.dashboard.additions.yml /
 
 WORKDIR /usr/src/app
@@ -38,10 +32,6 @@ ADD docker/start_notebook.sh /usr/src/app/.docker/start_notebook.sh
 RUN chmod u+x /usr/src/app/.docker/start_notebook.sh
 
 ADD docker/crontab /usr/src/app/crontab
-
-ADD docker/cert.sh /usr/src/app/.docker/cert.sh
-RUN chmod u+x /usr/src/app/.docker/cert.sh
-RUN /usr/src/app/.docker/cert.sh
 
 EXPOSE 8888
 


### PR DESCRIPTION
The other ENV vars that were added in Docker-compose files are currently present in the Dockerfile in the external repo root. Removing them from there and can add them as per requirement. For local testing, add them when “docker run” is used using the -e flag. For usage in stage / production, can be set by cloud team in AWS Codebuild as they currently do.

CRON_MODE
CRON_MODE can be moved to setting when docker run command is executed using -e flag. This is because this is required in start_notebook.sh in CMD layer in Dockerfile which is executed when the container is run. Hence, CRON_MODE value can be supplied later and not needed to be embedded in image.

PROD_STAGE
Not setting PROD_TRUE in docker run command since it is required during docker image build to decide whether to add certificates or not. Hence, adding it in the Dockerfile so it’s available during docker build.