### PR TITLE
Removed sed / jq usage from start scripts

### DIFF
--- a/viz_scripts/docker/start_notebook.sh
+++ b/viz_scripts/docker/start_notebook.sh
@@ -5,9 +5,8 @@
 echo "DB host = "${DB_HOST}
 if [ -z ${DB_HOST} ] ; then
     local_host=`hostname -i`
-    jq --arg db_host "$local_host" '.timeseries.url = $db_host' conf/storage/db.conf.sample > conf/storage/db.conf
-else
-    jq --arg db_host "$DB_HOST" '.timeseries.url = $db_host' conf/storage/db.conf.sample > conf/storage/db.conf
+    export DB_HOST=$local_host
+    echo "Setting db host environment variable to localhost"
 fi
 
 ### configure the saved-notebooks directory for persistent notebooks


### PR DESCRIPTION
Can directly set DB_HOST since we can now use environment variables. No need to use jq or sed to replace file contents and copy over files.